### PR TITLE
fix: post footer link corrected

### DIFF
--- a/src/components/Post/Author/Author.js
+++ b/src/components/Post/Author/Author.js
@@ -11,13 +11,14 @@ const Author = () => {
     <div className={styles['author']}>
       <p className={styles['author__bio']}>
         {author.bio}
+        <br />
         <a
-          className={styles['author__bio-twitter']}
-          href={getContactHref('twitter', author.contacts.twitter)}
+          className={styles['author__bio-linkedin']}
+          href={getContactHref('linkedin', author.contacts.linkedin)}
           rel="noopener noreferrer"
           target="_blank"
         >
-          <strong>{author.name}</strong> on Twitter
+          <strong>{author.name}</strong> on LinkedIn
         </a>
       </p>
     </div>

--- a/src/components/Post/Author/__snapshots__/Author.test.js.snap
+++ b/src/components/Post/Author/__snapshots__/Author.test.js.snap
@@ -8,16 +8,17 @@ exports[`Author renders correctly 1`] = `
     className="author__bio"
   >
     Test bio
+    <br />
     <a
-      className="author__bio-twitter"
-      href="https://www.twitter.com/#"
+      className="author__bio-linkedin"
+      href="https://www.linkedin.com/in/undefined"
       rel="noopener noreferrer"
       target="_blank"
     >
       <strong>
         Test name
       </strong>
-       on Twitter
+       on LinkedIn
     </a>
   </p>
 </div>

--- a/src/components/Post/__snapshots__/Post.test.js.snap
+++ b/src/components/Post/__snapshots__/Post.test.js.snap
@@ -79,16 +79,17 @@ exports[`Post renders correctly 1`] = `
         className="author__bio"
       >
         Test bio
+        <br />
         <a
-          className="author__bio-twitter"
-          href="https://www.twitter.com/#"
+          className="author__bio-linkedin"
+          href="https://www.linkedin.com/in/undefined"
           rel="noopener noreferrer"
           target="_blank"
         >
           <strong>
             Test name
           </strong>
-           on Twitter
+           on LinkedIn
         </a>
       </p>
     </div>

--- a/src/templates/__snapshots__/post-template.test.js.snap
+++ b/src/templates/__snapshots__/post-template.test.js.snap
@@ -82,16 +82,17 @@ exports[`PostTemplate renders correctly 1`] = `
           className="author__bio"
         >
           Test bio
+          <br />
           <a
-            className="author__bio-twitter"
-            href="https://www.twitter.com/#"
+            className="author__bio-linkedin"
+            href="https://www.linkedin.com/in/undefined"
             rel="noopener noreferrer"
             target="_blank"
           >
             <strong>
               Test name
             </strong>
-             on Twitter
+             on LinkedIn
           </a>
         </p>
       </div>


### PR DESCRIPTION
## Description

Uses LinkedIn link instead of Twitter on each blog post's footer.